### PR TITLE
Modified peer dependency to mocha to allow all future versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "coffee-script": "~1.7.1"
   },
   "peerDependencies": {
-    "mocha": "~1.20.1"
+    "mocha": ">=1.20.1"
   },
   "devDependencies": {
     "expect.js": "~0.3.1",


### PR DESCRIPTION
  The version for the mocha peer dependency was specified as "~1.20.1"
  which does not allow any versions of mocha from 1.21.0 and up to be
  installed alongside mocha-given. This update allows all future
  versions of mocha to be installed together with mocha-given.

  Defining peer dependencies in this way seems to be the de facto
  standard.
